### PR TITLE
feat: support provider-based agent CLI execution

### DIFF
--- a/be/app/config.py
+++ b/be/app/config.py
@@ -1,6 +1,6 @@
 from typing import ClassVar, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -26,10 +26,21 @@ class LoggingSettings(BaseModel):
 class LLMSettings(BaseModel):
     # LLM ops run via CLI subprocess (claude / codex) — no API keys stored here.
     # Authenticate once with: `claude auth login` or similar.
-    cli_tool: Literal["claude", "codex"] = "claude"
+    provider: Literal["claude", "codex"] = "claude"
+    deprecated_cli_tool: Literal["claude", "codex"] | None = Field(
+        default=None,
+        validation_alias="cli_tool",
+        exclude=True,
+    )
     model: str = "claude-sonnet-4-6"
     timeout_seconds: int = 120
     max_retries: int = 2
+
+    @model_validator(mode="after")
+    def _apply_deprecated_cli_tool(self) -> "LLMSettings":
+        if self.deprecated_cli_tool is not None:
+            self.provider = self.deprecated_cli_tool
+        return self
 
 
 class AnalysisSettings(BaseModel):

--- a/be/app/infrastructure/agent_cli/__init__.py
+++ b/be/app/infrastructure/agent_cli/__init__.py
@@ -1,0 +1,2 @@
+"""Agent CLI provider adapters."""
+

--- a/be/app/infrastructure/agent_cli/base.py
+++ b/be/app/infrastructure/agent_cli/base.py
@@ -31,9 +31,11 @@ class AgentCliProvider(Protocol):
 
     async def health_check(self) -> AgentCliHealth:
         """Return readiness information for diagnostics."""
+        ...
 
     async def list_mcp_sources(self) -> list[str]:
         """Return configured MCP source names understood by the app."""
+        ...
 
     async def run_prompt(
         self,
@@ -42,4 +44,5 @@ class AgentCliProvider(Protocol):
         timeout_seconds: int,
     ) -> str:
         """Run a non-interactive prompt and return stdout text."""
+        ...
 

--- a/be/app/infrastructure/agent_cli/base.py
+++ b/be/app/infrastructure/agent_cli/base.py
@@ -1,0 +1,45 @@
+"""Shared agent CLI provider contracts."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class AgentCliHealth:
+    provider: str
+    installed: bool
+    authenticated: bool | None
+    mcp_available: bool
+    mcp_sources: list[str]
+    errors: list[str]
+
+
+class AgentCliError(Exception):
+    """Base exception for agent CLI provider failures."""
+
+
+class AgentCliUnavailableError(AgentCliError):
+    """Raised when the configured CLI executable is unavailable."""
+
+
+class AgentCliTimeoutError(AgentCliError):
+    """Raised when the configured CLI exceeds its timeout."""
+
+
+class AgentCliProvider(Protocol):
+    name: str
+
+    async def health_check(self) -> AgentCliHealth:
+        """Return readiness information for diagnostics."""
+
+    async def list_mcp_sources(self) -> list[str]:
+        """Return configured MCP source names understood by the app."""
+
+    async def run_prompt(
+        self,
+        prompt: str,
+        model: str,
+        timeout_seconds: int,
+    ) -> str:
+        """Run a non-interactive prompt and return stdout text."""
+

--- a/be/app/infrastructure/agent_cli/claude.py
+++ b/be/app/infrastructure/agent_cli/claude.py
@@ -1,0 +1,49 @@
+"""Claude CLI provider adapter."""
+
+from app.infrastructure.agent_cli.base import (
+    AgentCliError,
+    AgentCliHealth,
+    AgentCliProvider,
+)
+from app.infrastructure.agent_cli.common import parse_known_mcp_sources, run_cli, stderr_summary
+
+
+class ClaudeCliProvider(AgentCliProvider):
+    name = "claude"
+
+    async def health_check(self) -> AgentCliHealth:
+        errors: list[str] = []
+        installed = True
+        mcp_sources: list[str] = []
+        try:
+            returncode, stdout, stderr = await run_cli(["claude", "mcp", "list"], timeout=5)
+            if returncode != 0:
+                errors.append(stderr_summary(stderr, "Claude MCP probe failed"))
+            else:
+                mcp_sources = parse_known_mcp_sources(stdout.decode(errors="replace"))
+        except AgentCliError as exc:
+            installed = False
+            errors.append(str(exc))
+
+        return AgentCliHealth(
+            provider=self.name,
+            installed=installed,
+            authenticated=None,
+            mcp_available=bool(mcp_sources),
+            mcp_sources=mcp_sources,
+            errors=errors,
+        )
+
+    async def list_mcp_sources(self) -> list[str]:
+        returncode, stdout, stderr = await run_cli(["claude", "mcp", "list"], timeout=5)
+        if returncode != 0:
+            raise AgentCliError(stderr_summary(stderr, "Claude MCP probe failed"))
+        return parse_known_mcp_sources(stdout.decode(errors="replace"))
+
+    async def run_prompt(self, prompt: str, model: str, timeout_seconds: int) -> str:
+        cmd = ["claude", "--model", model, "-p", prompt] if model else ["claude", "-p", prompt]
+        returncode, stdout, stderr = await run_cli(cmd, timeout=timeout_seconds)
+        if returncode != 0:
+            raise AgentCliError(stderr_summary(stderr, f"Claude exited with code {returncode}"))
+        return stdout.decode(errors="replace").strip()
+

--- a/be/app/infrastructure/agent_cli/codex.py
+++ b/be/app/infrastructure/agent_cli/codex.py
@@ -1,0 +1,52 @@
+"""Codex CLI provider adapter."""
+
+from app.infrastructure.agent_cli.base import (
+    AgentCliError,
+    AgentCliHealth,
+    AgentCliProvider,
+)
+from app.infrastructure.agent_cli.common import parse_known_mcp_sources, run_cli, stderr_summary
+
+
+class CodexCliProvider(AgentCliProvider):
+    name = "codex"
+
+    async def health_check(self) -> AgentCliHealth:
+        errors: list[str] = []
+        installed = True
+        mcp_sources: list[str] = []
+        try:
+            returncode, stdout, stderr = await run_cli(["codex", "mcp", "list"], timeout=5)
+            if returncode != 0:
+                errors.append(stderr_summary(stderr, "Codex MCP probe failed"))
+            else:
+                mcp_sources = parse_known_mcp_sources(stdout.decode(errors="replace"))
+        except AgentCliError as exc:
+            installed = False
+            errors.append(str(exc))
+
+        return AgentCliHealth(
+            provider=self.name,
+            installed=installed,
+            authenticated=None,
+            mcp_available=bool(mcp_sources),
+            mcp_sources=mcp_sources,
+            errors=errors,
+        )
+
+    async def list_mcp_sources(self) -> list[str]:
+        returncode, stdout, stderr = await run_cli(["codex", "mcp", "list"], timeout=5)
+        if returncode != 0:
+            raise AgentCliError(stderr_summary(stderr, "Codex MCP probe failed"))
+        return parse_known_mcp_sources(stdout.decode(errors="replace"))
+
+    async def run_prompt(self, prompt: str, model: str, timeout_seconds: int) -> str:
+        cmd = ["codex", "exec"]
+        if model:
+            cmd.extend(["--model", model])
+        cmd.append("-")
+        returncode, stdout, stderr = await run_cli(cmd, timeout=timeout_seconds, stdin=prompt)
+        if returncode != 0:
+            raise AgentCliError(stderr_summary(stderr, f"Codex exited with code {returncode}"))
+        return stdout.decode(errors="replace").strip()
+

--- a/be/app/infrastructure/agent_cli/common.py
+++ b/be/app/infrastructure/agent_cli/common.py
@@ -1,0 +1,46 @@
+"""Shared subprocess helpers for agent CLI providers."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+
+from app.infrastructure.agent_cli.base import AgentCliTimeoutError, AgentCliUnavailableError
+
+KNOWN_MCP_SOURCES = {"slack", "confluence", "jira", "notion", "linear"}
+
+
+async def run_cli(
+    args: list[str],
+    *,
+    timeout: float,
+    stdin: str | None = None,
+) -> tuple[int, bytes, bytes]:
+    """Run a CLI subprocess in a thread so it works across event loop policies."""
+
+    def _run() -> tuple[int, bytes, bytes]:
+        try:
+            result = subprocess.run(
+                args,
+                input=stdin.encode() if stdin is not None else None,
+                capture_output=True,
+                timeout=timeout,
+            )
+            return result.returncode, result.stdout, result.stderr
+        except subprocess.TimeoutExpired as exc:
+            raise AgentCliTimeoutError(f"`{args[0]}` timed out after {timeout}s") from exc
+        except FileNotFoundError as exc:
+            raise AgentCliUnavailableError(f"`{args[0]}` not found on PATH") from exc
+
+    return await asyncio.to_thread(_run)
+
+
+def parse_known_mcp_sources(output: str) -> list[str]:
+    lowered = output.lower()
+    return [source for source in sorted(KNOWN_MCP_SOURCES) if source in lowered]
+
+
+def stderr_summary(stderr: bytes, fallback: str) -> str:
+    text = stderr.decode(errors="replace").strip()
+    return text[:300] if text else fallback
+

--- a/be/app/infrastructure/agent_cli/factory.py
+++ b/be/app/infrastructure/agent_cli/factory.py
@@ -1,0 +1,14 @@
+"""Factory for configured agent CLI providers."""
+
+from app.infrastructure.agent_cli.base import AgentCliProvider
+from app.infrastructure.agent_cli.claude import ClaudeCliProvider
+from app.infrastructure.agent_cli.codex import CodexCliProvider
+
+
+def create_agent_cli_provider(provider: str) -> AgentCliProvider:
+    if provider == "claude":
+        return ClaudeCliProvider()
+    if provider == "codex":
+        return CodexCliProvider()
+    raise ValueError(f"Unsupported agent CLI provider: {provider}")
+

--- a/be/app/infrastructure/analysis/pipeline/llm_runner.py
+++ b/be/app/infrastructure/analysis/pipeline/llm_runner.py
@@ -1,15 +1,13 @@
-"""Shared LLM subprocess runner — call CLI and parse JSON output.
+"""Shared LLM runner — call the configured agent CLI provider and parse JSON output."""
 
-Uses asyncio.to_thread(subprocess.run) instead of asyncio.create_subprocess_exec
-so the call works on any event loop type — including the SelectorEventLoop that
-uvicorn uses in --reload mode on Windows.
-"""
-
-import asyncio
 import json
 import re
-import subprocess
 
+from app.infrastructure.agent_cli.base import (
+    AgentCliProvider,
+    AgentCliTimeoutError,
+    AgentCliUnavailableError,
+)
 from app.logger import get_logger
 
 logger = get_logger(__name__)
@@ -22,7 +20,7 @@ class LLMCallError(Exception):
 
 
 async def call_llm(
-    cli_tool: str,
+    provider: AgentCliProvider,
     model: str,
     prompt: str,
     timeout_seconds: int = 120,
@@ -35,7 +33,7 @@ async def call_llm(
     """
     logger.debug(
         "LLM call starting: tool=%s model=%s timeout=%ds retries=%d prompt_len=%d\nPROMPT>>>\n%s\n<<<",
-        cli_tool,
+        provider.name,
         model,
         timeout_seconds,
         max_retries,
@@ -46,10 +44,14 @@ async def call_llm(
     last_error: str = ""
     for attempt in range(1, max_retries + 2):
         logger.debug(
-            "LLM attempt %d/%d: tool=%s model=%s", attempt, max_retries + 1, cli_tool, model
+            "LLM attempt %d/%d: tool=%s model=%s",
+            attempt,
+            max_retries + 1,
+            provider.name,
+            model,
         )
         try:
-            raw = await _run_subprocess(cli_tool, model, prompt, timeout_seconds)
+            raw = await provider.run_prompt(prompt, model, timeout_seconds)
             logger.debug(
                 "LLM attempt %d/%d raw response (len=%d):\n%s",
                 attempt,
@@ -71,26 +73,26 @@ async def call_llm(
             logger.warning(
                 "LLM attempt %d/%d returned non-JSON: %s", attempt, max_retries + 1, raw[:200]
             )
-        except TimeoutError:
+        except AgentCliTimeoutError:
             last_error = f"Timed out after {timeout_seconds}s"
             logger.warning(
                 "LLM attempt %d/%d timed out after %ds", attempt, max_retries + 1, timeout_seconds
             )
-        except FileNotFoundError:
+        except AgentCliUnavailableError:
             # On Windows, concurrent subprocess spawns can transiently fail with
             # FileNotFoundError even when the executable exists on PATH.
             # Retry on all attempts except the last; only then treat it as permanent.
             if attempt == max_retries + 1:
                 raise LLMCallError(
-                    f"LLM CLI `{cli_tool}` not found on PATH. "
+                    f"LLM CLI `{provider.name}` not found on PATH. "
                     "Install and authenticate it to enable analysis pipeline."
                 ) from None
-            last_error = f"CLI `{cli_tool}` not found (transient, will retry)"
+            last_error = f"CLI `{provider.name}` not found (transient, will retry)"
             logger.warning(
                 "LLM attempt %d/%d FileNotFoundError for '%s' — likely transient on Windows, retrying",
                 attempt,
                 max_retries + 1,
-                cli_tool,
+                provider.name,
             )
         except Exception as exc:
             last_error = str(exc)
@@ -99,31 +101,6 @@ async def call_llm(
     raise LLMCallError(
         f"LLM call failed after {max_retries + 1} attempts. Last error: {last_error}"
     )
-
-
-async def _run_subprocess(
-    cli_tool: str,
-    model: str,
-    prompt: str,
-    timeout_seconds: int,
-) -> str:
-    cmd = [cli_tool, "--model", model, "-p", prompt]
-
-    def _run() -> str:
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                timeout=timeout_seconds,
-            )
-        except subprocess.TimeoutExpired:
-            raise TimeoutError(f"LLM CLI timed out after {timeout_seconds}s") from None
-        if result.returncode != 0:
-            err = result.stderr.decode(errors="replace").strip()
-            raise RuntimeError(f"CLI exited {result.returncode}: {err[:300]}")
-        return result.stdout.decode(errors="replace").strip()
-
-    return await asyncio.to_thread(_run)
 
 
 def _parse_json(raw: str) -> dict | list | None:  # type: ignore[type-arg]

--- a/be/app/infrastructure/analysis/pipeline/output_runner.py
+++ b/be/app/infrastructure/analysis/pipeline/output_runner.py
@@ -17,6 +17,7 @@ from app.domain.analysis.entities import (
     KptItem,
     Milestone,
 )
+from app.infrastructure.agent_cli.base import AgentCliProvider
 from app.infrastructure.analysis.pipeline.llm_runner import LLMCallError, call_llm
 from app.infrastructure.analysis.prompts.p4_ui_summary import build_p4_prompt
 from app.infrastructure.analysis.prompts.p5_kpt import build_p5_prompt
@@ -46,6 +47,7 @@ async def run_output_generation(
     behavioral_events: list[BehavioralEvent],
     session: AsyncSession,
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
 ) -> None:
     """Run P4 (parallel) + P5 + P6 + P7 + milestone derivation + snapshot persist."""
     member_repo = SqlMemberRepository(session)
@@ -69,7 +71,14 @@ async def run_output_generation(
     # ── Phase A: P4 — dimension UI summaries (parallel) ───────────────────────
     scored_dims = [ds for ds in dimension_scores if ds.p3_inference is not None]
     logger.info("P4 starting: run_id=%s scored_dims=%d", run.analysis_run_id, len(scored_dims))
-    await _run_p4_parallel(scored_dims, run.analysis_run_id, dim_score_repo, session, llm_settings)
+    await _run_p4_parallel(
+        scored_dims,
+        run.analysis_run_id,
+        dim_score_repo,
+        session,
+        llm_settings,
+        provider,
+    )
     await session.commit()
 
     # Reload dimension scores (now with ui_summary populated)
@@ -112,6 +121,7 @@ async def run_output_generation(
             top_strength_ids=top_strength_ids,
             top_growth_ids=top_growth_ids,
             llm_settings=llm_settings,
+            provider=provider,
             now=now,
         ),
         _run_p6(
@@ -121,6 +131,7 @@ async def run_output_generation(
             dim_summaries=dim_summaries,
             top_growth_ids=top_growth_ids,
             llm_settings=llm_settings,
+            provider=provider,
             now=now,
         ),
         _run_p7(
@@ -131,6 +142,7 @@ async def run_output_generation(
             dimension_scores=dimension_scores,
             overall_confidence=overall_confidence,
             llm_settings=llm_settings,
+            provider=provider,
         ),
     )
     profile_summary, growth_journey_summary, current_growth_path = p7_result
@@ -197,6 +209,7 @@ async def _run_p4_parallel(
     dim_score_repo: SqlDimensionScoreRepository,
     session: AsyncSession,
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
 ) -> None:
     semaphore = asyncio.Semaphore(_P4_CONCURRENT)
 
@@ -207,7 +220,7 @@ async def _run_p4_parallel(
             prompt = build_p4_prompt(ds.dimension_id, ds.p3_inference)
             try:
                 result = await call_llm(
-                    cli_tool=llm_settings.cli_tool,
+                    provider=provider,
                     model=llm_settings.model,
                     prompt=prompt,
                     timeout_seconds=llm_settings.timeout_seconds,
@@ -234,6 +247,7 @@ async def _run_p5(
     top_strength_ids: list[str],
     top_growth_ids: list[str],
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
     now: str,
 ) -> list[KptItem]:
     prompt = build_p5_prompt(
@@ -247,7 +261,7 @@ async def _run_p5(
     )
     try:
         result = await call_llm(
-            cli_tool=llm_settings.cli_tool,
+            provider=provider,
             model=llm_settings.model,
             prompt=prompt,
             timeout_seconds=llm_settings.timeout_seconds,
@@ -299,6 +313,7 @@ async def _run_p6(
     dim_summaries: list[dict],  # type: ignore[type-arg]
     top_growth_ids: list[str],
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
     now: str,
 ) -> list[CaseFeedback]:
     prompt = build_p6_prompt(
@@ -312,7 +327,7 @@ async def _run_p6(
     )
     try:
         result = await call_llm(
-            cli_tool=llm_settings.cli_tool,
+            provider=provider,
             model=llm_settings.model,
             prompt=prompt,
             timeout_seconds=llm_settings.timeout_seconds,
@@ -369,6 +384,7 @@ async def _run_p7(
     dimension_scores: list[DimensionScore],
     overall_confidence: float,
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
 ) -> tuple[str | None, str | None, str | None]:
     cat_scores_for_prompt = [
         {"category_id": ds.dimension_id, "score": ds.normalized_score}
@@ -388,7 +404,7 @@ async def _run_p7(
     )
     try:
         result = await call_llm(
-            cli_tool=llm_settings.cli_tool,
+            provider=provider,
             model=llm_settings.model,
             prompt=prompt,
             timeout_seconds=llm_settings.timeout_seconds,

--- a/be/app/infrastructure/analysis/pipeline/p1_runner.py
+++ b/be/app/infrastructure/analysis/pipeline/p1_runner.py
@@ -5,6 +5,7 @@ import uuid
 
 from app.domain.analysis.entities import EvidenceUnit
 from app.domain.analysis.taxonomy import VALID_POLARITIES
+from app.infrastructure.agent_cli.base import AgentCliProvider
 from app.infrastructure.analysis.pipeline.chunker import build_content_excerpt, chunk_records
 from app.infrastructure.analysis.pipeline.llm_runner import LLMCallError, call_llm
 from app.infrastructure.analysis.prompts.p1_extraction import build_p1_prompt
@@ -23,7 +24,7 @@ async def run_p1(
     period_start: str,
     period_end: str,
     source_records: list[dict],  # type: ignore[type-arg]  # from parsed source_payloads
-    cli_tool: str,
+    provider: AgentCliProvider,
     model: str,
     timeout_seconds: int,
     max_retries: int,
@@ -97,7 +98,7 @@ async def run_p1(
             )
             try:
                 result = await call_llm(
-                    cli_tool=cli_tool,
+                    provider=provider,
                     model=model,
                     prompt=prompt,
                     timeout_seconds=timeout_seconds,

--- a/be/app/infrastructure/analysis/pipeline/p2_runner.py
+++ b/be/app/infrastructure/analysis/pipeline/p2_runner.py
@@ -8,6 +8,7 @@ from app.domain.analysis.taxonomy import (
     VALID_OPPORTUNITY_LEVELS,
     VALID_POLARITIES,
 )
+from app.infrastructure.agent_cli.base import AgentCliProvider
 from app.infrastructure.analysis.pipeline.llm_runner import LLMCallError, call_llm
 from app.infrastructure.analysis.prompts.p2_consolidation import build_p2_prompt
 from app.infrastructure.db.base import utcnow
@@ -20,7 +21,7 @@ async def run_p2(
     run_id: str,
     member_id: str,
     candidate_events: list[dict],  # type: ignore[type-arg]  # from P1
-    cli_tool: str,
+    provider: AgentCliProvider,
     model: str,
     timeout_seconds: int,
     max_retries: int,
@@ -38,7 +39,7 @@ async def run_p2(
     prompt = build_p2_prompt(candidate_events)
     try:
         result = await call_llm(
-            cli_tool=cli_tool,
+            provider=provider,
             model=model,
             prompt=prompt,
             timeout_seconds=timeout_seconds,

--- a/be/app/infrastructure/analysis/pipeline/p3_runner.py
+++ b/be/app/infrastructure/analysis/pipeline/p3_runner.py
@@ -3,6 +3,7 @@
 import asyncio
 
 from app.domain.analysis.taxonomy import DIMENSION_IDS
+from app.infrastructure.agent_cli.base import AgentCliProvider
 from app.infrastructure.analysis.pipeline.llm_runner import LLMCallError, call_llm
 from app.infrastructure.analysis.prompts.p3_inference import build_p3_prompt
 from app.logger import get_logger
@@ -17,7 +18,7 @@ async def run_p3(
     behavioral_events: list[dict],  # type: ignore[type-arg]
     role_profile_summary: str,
     baseline_summary: str,
-    cli_tool: str,
+    provider: AgentCliProvider,
     model: str,
     timeout_seconds: int,
     max_retries: int,
@@ -54,7 +55,7 @@ async def run_p3(
             logger.debug("P3: inferring dim=%s run=%s events=%d", dim_id, run_id, len(dim_events))
             try:
                 result = await call_llm(
-                    cli_tool=cli_tool,
+                    provider=provider,
                     model=model,
                     prompt=prompt,
                     timeout_seconds=timeout_seconds,

--- a/be/app/infrastructure/analysis/pipeline/p8_runner.py
+++ b/be/app/infrastructure/analysis/pipeline/p8_runner.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import LLMSettings
 from app.domain.analysis.entities import AnalysisRun
+from app.infrastructure.agent_cli.base import AgentCliProvider
 from app.infrastructure.analysis.pipeline.llm_runner import LLMCallError, call_llm
 from app.infrastructure.analysis.prompts.p8_critique import build_p8_prompt
 from app.infrastructure.db.repositories.analysis import (
@@ -21,6 +22,7 @@ async def run_p8(
     run: AnalysisRun,
     session: AsyncSession,
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
 ) -> None:
     """Run P8 self-critique gate.
 
@@ -56,6 +58,7 @@ async def run_p8(
         growth_journey_summary=snapshot.growth_journey_summary,
         overall_confidence=snapshot.overall_confidence or 0.0,
         llm_settings=llm_settings,
+        provider=provider,
     )
 
     logger.debug(
@@ -117,6 +120,7 @@ async def run_p8(
             growth_journey_summary=patched_journey,
             overall_confidence=snapshot.overall_confidence or 0.0,
             llm_settings=llm_settings,
+            provider=provider,
         )
         logger.info(
             "P8 retry: run_id=%s approved=%s remaining_issues=%d",
@@ -149,6 +153,7 @@ async def _call_p8(
     growth_journey_summary: str | None,
     overall_confidence: float,
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
 ) -> tuple[bool, list[dict]]:  # type: ignore[type-arg]
     """Call LLM for P8 critique. Returns (approved, issues)."""
     prompt = build_p8_prompt(
@@ -160,7 +165,7 @@ async def _call_p8(
     )
     try:
         result = await call_llm(
-            cli_tool=llm_settings.cli_tool,
+            provider=provider,
             model=llm_settings.model,
             prompt=prompt,
             timeout_seconds=llm_settings.timeout_seconds,

--- a/be/app/infrastructure/analysis/pipeline/scoring_runner.py
+++ b/be/app/infrastructure/analysis/pipeline/scoring_runner.py
@@ -9,6 +9,7 @@ from app.domain.analysis.scoring_engine import (
     compute_category_scores,
     compute_dimension_scores,
 )
+from app.infrastructure.agent_cli.base import AgentCliProvider
 from app.infrastructure.analysis.pipeline.p3_runner import run_p3
 from app.infrastructure.db.base import utcnow
 from app.infrastructure.db.repositories.analysis import (
@@ -28,6 +29,7 @@ async def run_scoring(
     behavioral_events: list[BehavioralEvent],
     session: AsyncSession,
     llm_settings: LLMSettings,
+    provider: AgentCliProvider,
 ) -> None:
     """Run P3 + scoring engine for the given analysis run.
 
@@ -87,7 +89,7 @@ async def run_scoring(
         behavioral_events=events_as_dicts,
         role_profile_summary=role_profile_summary,
         baseline_summary=baseline_summary,
-        cli_tool=llm_settings.cli_tool,
+        provider=provider,
         model=llm_settings.model,
         timeout_seconds=llm_settings.timeout_seconds,
         max_retries=llm_settings.max_retries,

--- a/be/app/infrastructure/analysis/runner.py
+++ b/be/app/infrastructure/analysis/runner.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import AnalysisSettings, LLMSettings
 from app.domain.analysis.entities import AnalysisRun, SourcePayload
 from app.domain.analysis.repositories import IAnalysisRunRepository
+from app.infrastructure.agent_cli.factory import create_agent_cli_provider
 from app.infrastructure.analysis.pipeline.output_runner import run_output_generation
 from app.infrastructure.analysis.pipeline.p1_runner import run_p1
 from app.infrastructure.analysis.pipeline.p2_runner import run_p2
@@ -116,6 +117,7 @@ async def _run_pipeline(
     evidence_repo = SqlEvidenceUnitRepository(session)
     event_repo = SqlBehavioralEventRepository(session)
     dim_score_repo = SqlDimensionScoreRepository(session)
+    agent_cli_provider = create_agent_cli_provider(llm_settings.provider)
 
     run = await run_repo.get_by_id(run_id)
     if run is None:
@@ -136,7 +138,7 @@ async def _run_pipeline(
 
     gh = GitHubCollector(timeout_seconds=analysis_settings.github_timeout_seconds)
     mcp = LLMMCPCollector(
-        cli_tool=llm_settings.cli_tool,
+        provider=agent_cli_provider,
         model=llm_settings.model,
         timeout_seconds=llm_settings.timeout_seconds,
     )
@@ -296,7 +298,7 @@ async def _run_pipeline(
         period_start=run.period_start,
         period_end=run.period_end,
         source_records=all_records,
-        cli_tool=llm_settings.cli_tool,
+        provider=agent_cli_provider,
         model=llm_settings.model,
         timeout_seconds=llm_settings.timeout_seconds,
         max_retries=llm_settings.max_retries,
@@ -313,7 +315,7 @@ async def _run_pipeline(
         run_id=run_id,
         member_id=run.member_id,
         candidate_events=candidate_events,
-        cli_tool=llm_settings.cli_tool,
+        provider=agent_cli_provider,
         model=llm_settings.model,
         timeout_seconds=llm_settings.timeout_seconds,
         max_retries=llm_settings.max_retries,
@@ -346,6 +348,7 @@ async def _run_pipeline(
         behavioral_events=behavioral_events,
         session=session,
         llm_settings=llm_settings,
+        provider=agent_cli_provider,
     )
 
     run.progress_stage = "scoring"
@@ -368,6 +371,7 @@ async def _run_pipeline(
         behavioral_events=behavioral_events,
         session=session,
         llm_settings=llm_settings,
+        provider=agent_cli_provider,
     )
 
     # ── Phase 5: P8 Self-Critique Gate ────────────────────────────────────────
@@ -377,7 +381,12 @@ async def _run_pipeline(
     await run_repo.update(run)
     await session.commit()
 
-    await run_p8(run=run, session=session, llm_settings=llm_settings)
+    await run_p8(
+        run=run,
+        session=session,
+        llm_settings=llm_settings,
+        provider=agent_cli_provider,
+    )
 
     # ── Completed ─────────────────────────────────────────────────────────────
     run.status = "completed"

--- a/be/app/infrastructure/collectors/llm_mcp.py
+++ b/be/app/infrastructure/collectors/llm_mcp.py
@@ -5,20 +5,21 @@ The backend never holds Slack/Confluence/Jira tokens. Instead it calls the LLM C
 fetch and return structured JSON. The LLM's own MCP configuration handles auth.
 """
 
-import json
-import re
-
+from app.infrastructure.agent_cli.base import (
+    AgentCliError,
+    AgentCliProvider,
+    AgentCliTimeoutError,
+    AgentCliUnavailableError,
+)
+from app.infrastructure.analysis.pipeline.llm_runner import _parse_json
 from app.infrastructure.collectors.base import (
     CollectionResult,
     CollectorTimeoutError,
     CollectorUnavailableError,
-    run_subprocess,
 )
 from app.logger import get_logger
 
 logger = get_logger(__name__)
-
-_KNOWN_MCP_SOURCES = {"slack", "confluence", "jira", "notion", "linear"}
 
 _COLLECTION_PROMPT_TEMPLATE = """\
 You have access to MCP tools. Collect developer activity data for analysis.
@@ -58,25 +59,30 @@ Return ONLY a valid JSON object (no markdown, no explanation) matching this sche
 class LLMMCPCollector:
     _SOURCE_TYPE: str = "mcp"
 
-    def __init__(self, cli_tool: str, model: str, timeout_seconds: int = 120) -> None:
-        self._cli = cli_tool
+    def __init__(
+        self,
+        provider: AgentCliProvider,
+        model: str,
+        timeout_seconds: int = 120,
+    ) -> None:
+        self._provider = provider
         self._model = model
         self._timeout = timeout_seconds
 
     async def probe_mcp_sources(self) -> list[str]:
-        """Detect which MCP servers are configured by running `<cli> mcp list`."""
+        """Detect which MCP servers are configured for the selected provider."""
         try:
-            _, stdout, _ = await run_subprocess(self._cli, "mcp", "list", timeout=5)
-            output = stdout.decode(errors="replace").lower()
-            found = [src for src in _KNOWN_MCP_SOURCES if src in output]
-            return found
-        except CollectorUnavailableError:
+            return await self._provider.list_mcp_sources()
+        except AgentCliUnavailableError:
             raise CollectorUnavailableError(
-                f"LLM CLI `{self._cli}` not found on PATH. "
+                f"LLM CLI `{self._provider.name}` not found on PATH. "
                 "Install and authenticate it before running analysis."
             ) from None
-        except CollectorTimeoutError:
+        except AgentCliTimeoutError:
             logger.warning("MCP probe timed out — assuming no MCP sources available")
+            return []
+        except AgentCliError as exc:
+            logger.warning("MCP probe failed for %s: %s", self._provider.name, exc)
             return []
 
     async def collect(
@@ -104,9 +110,13 @@ class LLMMCPCollector:
                 )
             ]
 
-        logger.debug("MCP probe result: cli=%s available_sources=%s", self._cli, available)
+        logger.debug(
+            "MCP probe result: provider=%s available_sources=%s",
+            self._provider.name,
+            available,
+        )
         if not available:
-            logger.info("No known MCP sources configured for %s — skipping", self._cli)
+            logger.info("No known MCP sources configured for %s — skipping", self._provider.name)
             return [
                 CollectionResult(
                     source_type="mcp",
@@ -160,35 +170,27 @@ class LLMMCPCollector:
 
     async def _run_llm(self, prompt: str) -> str | None:
         """Invoke the LLM CLI with a prompt and return its stdout."""
-        if self._model:
-            cmd = (self._cli, "--model", self._model, "-p", prompt)
-        else:
-            cmd = (self._cli, "-p", prompt)
         try:
-            returncode, stdout, stderr = await run_subprocess(*cmd, timeout=self._timeout)
-            if returncode != 0:
-                err = stderr.decode(errors="replace").strip()
-                logger.warning("LLM CLI exited with code %d: %s", returncode, err[:300])
-                return None
-
-            return stdout.decode(errors="replace").strip() or None
-
-        except CollectorTimeoutError:
-            raise
-        except CollectorUnavailableError:
-            raise CollectorUnavailableError(f"LLM CLI `{self._cli}` not found on PATH.") from None
+            return (
+                await self._provider.run_prompt(
+                    prompt=prompt,
+                    model=self._model,
+                    timeout_seconds=self._timeout,
+                )
+            ) or None
+        except AgentCliTimeoutError as exc:
+            raise CollectorTimeoutError(str(exc)) from exc
+        except AgentCliUnavailableError as exc:
+            raise CollectorUnavailableError(str(exc)) from exc
+        except AgentCliError as exc:
+            logger.warning("LLM CLI exited unsuccessfully: %s", exc)
+            return None
 
 
 def _parse_json_response(raw: str) -> dict | None:  # type: ignore[type-arg]
     """Extract a JSON object from LLM output (handles markdown code fences)."""
-    # Strip markdown code fences if present
-    stripped = re.sub(r"^```(?:json)?\s*", "", raw.strip(), flags=re.MULTILINE)
-    stripped = re.sub(r"\s*```$", "", stripped.strip(), flags=re.MULTILINE)
-    try:
-        result = json.loads(stripped)
-        return result if isinstance(result, dict) else None
-    except json.JSONDecodeError:
-        return None
+    result = _parse_json(raw)
+    return result if isinstance(result, dict) else None
 
 
 def _split_by_source(

--- a/be/config/default.yaml
+++ b/be/config/default.yaml
@@ -20,7 +20,7 @@ logging:
   format: "text"
 
 llm:
-  cli_tool: "claude" # "claude" | "codex" — must be on PATH and authenticated
+  provider: "claude" # "claude" | "codex" — must be on PATH and authenticated
   model: "claude-sonnet-4-6" # passed via --model flag when supported
   timeout_seconds: 120 # max seconds to wait for LLM CLI response
   max_retries: 2 # retries on transient subprocess failures

--- a/be/tests/infrastructure/test_agent_cli.py
+++ b/be/tests/infrastructure/test_agent_cli.py
@@ -1,0 +1,105 @@
+"""Unit tests for agent CLI provider command adapters."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from app.infrastructure.agent_cli.base import AgentCliError
+from app.infrastructure.agent_cli.claude import ClaudeCliProvider
+from app.infrastructure.agent_cli.codex import CodexCliProvider
+from app.infrastructure.agent_cli.factory import create_agent_cli_provider
+
+
+def _completed(
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+    returncode: int = 0,
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestAgentCliFactory:
+    def test_creates_claude_provider(self) -> None:
+        assert isinstance(create_agent_cli_provider("claude"), ClaudeCliProvider)
+
+    def test_creates_codex_provider(self) -> None:
+        assert isinstance(create_agent_cli_provider("codex"), CodexCliProvider)
+
+    def test_rejects_unknown_provider(self) -> None:
+        with pytest.raises(ValueError):
+            create_agent_cli_provider("unknown")
+
+
+class TestClaudeCliProvider:
+    async def test_run_prompt_uses_claude_prompt_command(self) -> None:
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return _completed(stdout=b'{"ok": true}')
+
+        with patch("app.infrastructure.agent_cli.common.subprocess.run", side_effect=fake_run):
+            result = await ClaudeCliProvider().run_prompt("hello", "claude-sonnet-4-6", 10)
+
+        assert result == '{"ok": true}'
+        assert calls[0][0] == ["claude", "--model", "claude-sonnet-4-6", "-p", "hello"]
+        assert calls[0][1]["input"] is None
+
+    async def test_list_mcp_sources_uses_claude_mcp_list(self) -> None:
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return _completed(stdout=b"slack\nlinear\n")
+
+        with patch("app.infrastructure.agent_cli.common.subprocess.run", side_effect=fake_run):
+            result = await ClaudeCliProvider().list_mcp_sources()
+
+        assert calls[0] == ["claude", "mcp", "list"]
+        assert result == ["linear", "slack"]
+
+
+class TestCodexCliProvider:
+    async def test_run_prompt_uses_codex_exec_with_stdin(self) -> None:
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return _completed(stdout=b'{"ok": true}')
+
+        with patch("app.infrastructure.agent_cli.common.subprocess.run", side_effect=fake_run):
+            result = await CodexCliProvider().run_prompt("hello", "gpt-5.4", 10)
+
+        assert result == '{"ok": true}'
+        assert calls[0][0] == ["codex", "exec", "--model", "gpt-5.4", "-"]
+        assert calls[0][1]["input"] == b"hello"
+
+    async def test_list_mcp_sources_uses_codex_mcp_list(self) -> None:
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return _completed(stdout=b"notion\njira\n")
+
+        with patch("app.infrastructure.agent_cli.common.subprocess.run", side_effect=fake_run):
+            result = await CodexCliProvider().list_mcp_sources()
+
+        assert calls[0] == ["codex", "mcp", "list"]
+        assert result == ["jira", "notion"]
+
+    async def test_nonzero_exit_includes_stderr(self) -> None:
+        def fake_run(args, **kwargs):
+            return _completed(stderr=b"not logged in", returncode=1)
+
+        with (
+            patch("app.infrastructure.agent_cli.common.subprocess.run", side_effect=fake_run),
+            pytest.raises(AgentCliError, match="not logged in"),
+        ):
+            await CodexCliProvider().run_prompt("hello", "gpt-5.4", 10)
+

--- a/be/tests/infrastructure/test_collectors.py
+++ b/be/tests/infrastructure/test_collectors.py
@@ -8,9 +8,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.infrastructure.agent_cli.base import (
+    AgentCliHealth,
+    AgentCliTimeoutError,
+    AgentCliUnavailableError,
+)
 from app.infrastructure.collectors.base import (
     CollectionResult,
-    CollectorTimeoutError,
     CollectorUnavailableError,
 )
 from app.infrastructure.collectors.github import GitHubCollector
@@ -28,7 +32,38 @@ def _fail(stderr: bytes = b"", returncode: int = 1) -> tuple[int, bytes, bytes]:
 
 
 _RUN_SUB_GH = "app.infrastructure.collectors.github.run_subprocess"
-_RUN_SUB_MCP = "app.infrastructure.collectors.llm_mcp.run_subprocess"
+
+
+class FakeAgentCliProvider:
+    name = "fake"
+
+    def __init__(
+        self,
+        sources: list[str] | None = None,
+        response: str | None = None,
+        list_error: Exception | None = None,
+    ) -> None:
+        self.sources = sources or []
+        self.response = response
+        self.list_error = list_error
+
+    async def health_check(self) -> AgentCliHealth:
+        return AgentCliHealth(
+            provider=self.name,
+            installed=True,
+            authenticated=None,
+            mcp_available=bool(self.sources),
+            mcp_sources=self.sources,
+            errors=[],
+        )
+
+    async def list_mcp_sources(self) -> list[str]:
+        if self.list_error:
+            raise self.list_error
+        return self.sources
+
+    async def run_prompt(self, prompt: str, model: str, timeout_seconds: int) -> str:
+        return self.response or ""
 
 
 # ── GitHubCollector ───────────────────────────────────────────────────────────
@@ -223,51 +258,43 @@ class TestGitHubCollectorPrParsing:
 
 
 class TestLLMMCPCollector:
-    def _make_collector(self) -> LLMMCPCollector:
-        return LLMMCPCollector(cli_tool="claude", model="claude-sonnet-4-6", timeout_seconds=10)
+    def _make_collector(self, provider: FakeAgentCliProvider) -> LLMMCPCollector:
+        return LLMMCPCollector(provider=provider, model="claude-sonnet-4-6", timeout_seconds=10)
 
     async def test_returns_skipped_when_cli_not_found(self) -> None:
-        collector = self._make_collector()
-        with patch(_RUN_SUB_MCP, AsyncMock(side_effect=CollectorUnavailableError("not found"))):
-            results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
+        collector = self._make_collector(
+            FakeAgentCliProvider(list_error=AgentCliUnavailableError("not found"))
+        )
+        results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
 
         assert len(results) == 1
         assert results[0].status == "skipped"
         assert results[0].source_type == "mcp"
 
     async def test_returns_skipped_when_no_mcp_sources_configured(self) -> None:
-        collector = self._make_collector()
-        with patch(_RUN_SUB_MCP, AsyncMock(return_value=_ok(b"No servers configured"))):
-            results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
+        collector = self._make_collector(FakeAgentCliProvider())
+        results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
 
         assert len(results) == 1
         assert results[0].status == "skipped"
         assert results[0].record_count == 0
 
     async def test_returns_skipped_when_probe_times_out(self) -> None:
-        collector = self._make_collector()
-        with patch(_RUN_SUB_MCP, AsyncMock(side_effect=CollectorTimeoutError("timed out"))):
-            results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
+        collector = self._make_collector(
+            FakeAgentCliProvider(list_error=AgentCliTimeoutError("timed out"))
+        )
+        results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
 
         assert len(results) == 1
         assert results[0].status == "skipped"
 
     async def test_returns_failed_when_llm_returns_no_output(self) -> None:
-        collector = self._make_collector()
-        call_count = 0
-
-        async def fake_run(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            return _ok(b"slack") if call_count == 1 else _ok(b"")
-
-        with patch(_RUN_SUB_MCP, side_effect=fake_run):
-            results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
+        collector = self._make_collector(FakeAgentCliProvider(sources=["slack"], response=""))
+        results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
 
         assert any(r.status == "failed" for r in results)
 
     async def test_parses_json_response_into_per_source_results(self) -> None:
-        collector = self._make_collector()
         response_json = json.dumps(
             {
                 "sources_queried": ["slack"],
@@ -284,20 +311,32 @@ class TestLLMMCPCollector:
                 "notes": "",
             }
         )
-        call_count = 0
-
-        async def fake_run(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            return _ok(b"slack") if call_count == 1 else _ok(response_json.encode())
-
-        with patch(_RUN_SUB_MCP, side_effect=fake_run):
-            results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
+        collector = self._make_collector(
+            FakeAgentCliProvider(sources=["slack"], response=response_json)
+        )
+        results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
 
         by_type = {r.source_type: r for r in results}
         assert by_type["slack"].status == "collected"
         assert by_type["slack"].record_count == 1
         assert by_type["jira"].status == "skipped"
+
+    async def test_parses_fenced_json_response(self) -> None:
+        response_json = """
+Here is the data:
+
+```json
+{"sources_queried":["slack"],"records":[],"unavailable_sources":[],"notes":""}
+```
+"""
+        collector = self._make_collector(
+            FakeAgentCliProvider(sources=["slack"], response=response_json)
+        )
+        results = await collector.collect("Alice", "alice", "2024-01-01", "2024-06-30")
+
+        assert len(results) == 1
+        assert results[0].source_type == "slack"
+        assert results[0].status == "collected"
 
 
 # ── Runner collection guard ───────────────────────────────────────────────────

--- a/docs/design/agent-cli-provider-design.md
+++ b/docs/design/agent-cli-provider-design.md
@@ -1,0 +1,409 @@
+# Agent CLI Provider Design
+
+## Goal
+
+Make the backend analysis pipeline support Codex as a first-class agent CLI provider while preserving the current Claude CLI behavior.
+
+The current configuration suggests support for multiple CLIs:
+
+```yaml
+llm:
+  cli_tool: "claude" # "claude" | "codex"
+```
+
+However, the implementation assumes one command shape:
+
+```bash
+<cli> --model <model> -p <prompt>
+<cli> mcp list
+```
+
+This is not a valid abstraction for all agent CLIs. Codex uses a different non-interactive command shape:
+
+```bash
+codex exec --model <model> <prompt>
+codex mcp list
+```
+
+The fix should introduce provider-specific adapters so the rest of the backend does not need to know each CLI's command syntax.
+
+## Current Weakness
+
+The backend treats `cli_tool` as only an executable name, but an agent CLI provider is actually a contract:
+
+- how to run a prompt
+- how to pass a model
+- how to pass long prompt input
+- how to list MCP servers
+- how to check installation/auth readiness
+- how to classify failures
+- how to parse returned output
+
+Because those details are not isolated, Claude-specific assumptions are spread across:
+
+- `be/app/infrastructure/collectors/llm_mcp.py`
+- `be/app/infrastructure/analysis/pipeline/llm_runner.py`
+- `be/app/config.py`
+- `be/config/default.yaml`
+
+## API Contract
+
+No public API contract should change for this implementation.
+
+Keep these endpoint behaviors unchanged:
+
+- `POST /api/v1/analysis-runs`
+- `GET /api/v1/analysis-runs/{run_id}`
+- profile read APIs that depend on completed analysis runs
+
+Optional new endpoint:
+
+- `GET /api/v1/system/agent-cli-health`
+
+This endpoint is useful but not required for the first implementation if startup logging is simpler.
+
+## Proposed Architecture
+
+Add a provider layer under infrastructure:
+
+```text
+be/app/infrastructure/agent_cli/
+  __init__.py
+  base.py
+  claude.py
+  codex.py
+  factory.py
+```
+
+The analysis pipeline and MCP collector should depend on the provider interface, not raw CLI command construction.
+
+## Future CLI Extensibility Memo
+
+Adding another CLI agent should be additive after this change:
+
+1. Add one provider file, for example `be/app/infrastructure/agent_cli/gemini.py`.
+2. Implement that CLI's command shape behind `AgentCliProvider`.
+3. Register it in `be/app/infrastructure/agent_cli/factory.py`.
+4. Add the provider name to config validation.
+5. Add focused tests for command construction, stdin handling, MCP listing, and error mapping.
+
+The shared pipeline should not change for new CLI agents as long as the agent can satisfy the core contract: non-interactive prompt in, text or JSON out, and optional MCP source listing. If a future CLI cannot support MCP or requires streaming/interactive sessions, add explicit capability fields such as `supports_mcp` or `supports_stdin_prompt` instead of adding provider-specific branches in the pipeline.
+
+## File Changes
+
+### 1. `be/app/config.py`
+
+Replace `cli_tool` with a provider-oriented name.
+
+Current:
+
+```python
+class LLMSettings(BaseModel):
+    cli_tool: Literal["claude", "codex"] = "claude"
+    model: str = "claude-sonnet-4-6"
+    timeout_seconds: int = 120
+    max_retries: int = 2
+```
+
+Proposed:
+
+```python
+class LLMSettings(BaseModel):
+    provider: Literal["claude", "codex"] = "claude"
+    model: str = "claude-sonnet-4-6"
+    timeout_seconds: int = 120
+    max_retries: int = 2
+```
+
+Compatibility option:
+
+- Keep `cli_tool` temporarily as deprecated input if migration risk is high.
+- Internally map `cli_tool` to `provider`.
+
+### 2. `be/config/default.yaml`
+
+Current:
+
+```yaml
+llm:
+  cli_tool: "claude"
+  model: "claude-sonnet-4-6"
+```
+
+Proposed:
+
+```yaml
+llm:
+  provider: "claude"
+  model: "claude-sonnet-4-6"
+  timeout_seconds: 120
+  max_retries: 2
+```
+
+Codex local override example:
+
+```yaml
+llm:
+  provider: "codex"
+  model: "gpt-5.4"
+```
+
+### 3. `be/app/infrastructure/agent_cli/base.py`
+
+Create shared types and protocol.
+
+```python
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class AgentCliHealth:
+    provider: str
+    installed: bool
+    authenticated: bool | None
+    mcp_available: bool
+    mcp_sources: list[str]
+    errors: list[str]
+
+
+class AgentCliError(Exception):
+    pass
+
+
+class AgentCliUnavailableError(AgentCliError):
+    pass
+
+
+class AgentCliTimeoutError(AgentCliError):
+    pass
+
+
+class AgentCliProvider(Protocol):
+    name: str
+
+    async def health_check(self) -> AgentCliHealth:
+        ...
+
+    async def list_mcp_sources(self) -> list[str]:
+        ...
+
+    async def run_prompt(
+        self,
+        prompt: str,
+        model: str,
+        timeout_seconds: int,
+    ) -> str:
+        ...
+```
+
+### 4. `be/app/infrastructure/agent_cli/claude.py`
+
+Implement current Claude behavior inside an adapter.
+
+Responsibilities:
+
+- run `claude mcp list`
+- run `claude --model <model> -p <prompt>`
+- return stdout as text
+- convert missing executable/timeouts/non-zero exit into provider errors
+
+Command mapping:
+
+```bash
+claude mcp list
+claude --model <model> -p <prompt>
+```
+
+### 5. `be/app/infrastructure/agent_cli/codex.py`
+
+Implement Codex behavior inside an adapter.
+
+Responsibilities:
+
+- run `codex mcp list`
+- run Codex non-interactively with `codex exec`
+- prefer stdin for long prompts
+- return final stdout as text
+- convert missing executable/timeouts/non-zero exit into provider errors
+
+Command mapping:
+
+```bash
+codex mcp list
+codex exec --model <model> -
+```
+
+Use `-` and pass the prompt via stdin to avoid command-line length issues.
+
+Recommended subprocess call:
+
+```python
+subprocess.run(
+    ["codex", "exec", "--model", model, "-"],
+    input=prompt.encode(),
+    capture_output=True,
+    timeout=timeout_seconds,
+)
+```
+
+### 6. `be/app/infrastructure/agent_cli/factory.py`
+
+Create the selected provider from settings.
+
+```python
+def create_agent_cli_provider(provider: str) -> AgentCliProvider:
+    if provider == "claude":
+        return ClaudeCliProvider()
+    if provider == "codex":
+        return CodexCliProvider()
+    raise ValueError(f"Unsupported agent CLI provider: {provider}")
+```
+
+### 7. `be/app/infrastructure/collectors/llm_mcp.py`
+
+Change constructor from executable fields to provider dependency.
+
+Current:
+
+```python
+LLMMCPCollector(cli_tool=llm_settings.cli_tool, model=llm_settings.model)
+```
+
+Proposed:
+
+```python
+LLMMCPCollector(provider=agent_cli_provider, model=llm_settings.model)
+```
+
+Replace direct subprocess calls:
+
+```python
+await run_subprocess(self._cli, "mcp", "list", timeout=5)
+await run_subprocess(*cmd, timeout=self._timeout)
+```
+
+with:
+
+```python
+available = await self._provider.list_mcp_sources()
+raw_response = await self._provider.run_prompt(prompt, self._model, self._timeout)
+```
+
+Also reuse the stronger JSON extraction behavior from `llm_runner.py`, because agent CLIs may return fenced JSON or short preamble text.
+
+### 8. `be/app/infrastructure/analysis/pipeline/llm_runner.py`
+
+Change `call_llm` to depend on provider, not command shape.
+
+Current:
+
+```python
+async def call_llm(cli_tool: str, model: str, prompt: str, ...)
+```
+
+Proposed:
+
+```python
+async def call_llm(provider: AgentCliProvider, model: str, prompt: str, ...)
+```
+
+Inside retry loop:
+
+```python
+raw = await provider.run_prompt(prompt, model, timeout_seconds)
+```
+
+Keep existing JSON parsing and retry behavior.
+
+### 9. Pipeline Call Sites
+
+Update these call sites to pass provider instead of `cli_tool`:
+
+- `be/app/infrastructure/analysis/runner.py`
+- `be/app/infrastructure/analysis/pipeline/p1_runner.py`
+- `be/app/infrastructure/analysis/pipeline/p2_runner.py`
+- `be/app/infrastructure/analysis/pipeline/p3_runner.py`
+- `be/app/infrastructure/analysis/pipeline/scoring_runner.py`
+- `be/app/infrastructure/analysis/pipeline/output_runner.py`
+- `be/app/infrastructure/analysis/pipeline/p8_runner.py`
+
+Keep model, timeout, and retry settings unchanged.
+
+### 10. Optional Health Endpoint
+
+Add:
+
+```text
+GET /api/v1/system/agent-cli-health
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "provider": "codex",
+    "installed": true,
+    "authenticated": true,
+    "mcp_available": true,
+    "mcp_sources": ["linear", "notion"],
+    "errors": []
+  }
+}
+```
+
+Files:
+
+```text
+be/app/interfaces/routers/system.py
+be/app/interfaces/schemas/system.py
+be/app/main.py
+```
+
+This endpoint is useful for UI/debuggability, but it can be deferred if the first implementation should stay smaller.
+
+## Implementation Order
+
+1. Add `agent_cli` provider package.
+2. Implement Claude adapter using the current behavior.
+3. Switch `llm_runner.py` to use the provider while keeping Claude behavior passing.
+4. Switch `LLMMCPCollector` to use the provider.
+5. Wire provider creation in `runner.py`.
+6. Add Codex adapter.
+7. Update config from `cli_tool` to `provider`.
+8. Add tests for Claude and Codex command construction.
+9. Update docs.
+10. Optionally add health endpoint.
+
+## Test Plan
+
+Add or update tests in:
+
+```text
+be/tests/infrastructure/test_collectors.py
+be/tests/infrastructure/test_agent_cli.py
+be/tests/infrastructure/test_llm_runner.py
+```
+
+Required cases:
+
+- Claude provider builds `claude --model <model> -p <prompt>`.
+- Claude provider lists MCP sources with `claude mcp list`.
+- Codex provider builds `codex exec --model <model> -`.
+- Codex provider passes prompt via stdin.
+- Codex provider lists MCP sources with `codex mcp list`.
+- Missing executable becomes provider unavailable error.
+- Non-zero CLI exit includes useful stderr in the error message.
+- MCP collector can parse bare JSON.
+- MCP collector can parse fenced JSON.
+- Analysis runner fails clearly when selected provider is unavailable.
+
+## Done Criteria
+
+- `llm.provider: "claude"` preserves existing behavior.
+- `llm.provider: "codex"` works through Codex CLI command shape.
+- No analysis pipeline code constructs provider-specific CLI commands directly.
+- Provider-specific behavior is isolated in adapter classes.
+- Config and docs no longer imply Codex support without implementation.
+- Tests cover both provider command shapes.

--- a/docs/design/agent-cli-provider-design.md
+++ b/docs/design/agent-cli-provider-design.md
@@ -21,7 +21,7 @@ However, the implementation assumes one command shape:
 This is not a valid abstraction for all agent CLIs. Codex uses a different non-interactive command shape:
 
 ```bash
-codex exec --model <model> <prompt>
+codex exec --model <model> -
 codex mcp list
 ```
 

--- a/docs/design/human-analysis-MVP-specs/mvp-build-plan.md
+++ b/docs/design/human-analysis-MVP-specs/mvp-build-plan.md
@@ -40,7 +40,7 @@
 | Frontend | Next.js (TypeScript) |
 | Backend | Python 3.12 · FastAPI · SQLAlchemy · aiosqlite |
 | Database | SQLite (dev) |
-| AI Pipeline | Claude CLI subprocess (`claude --model claude-sonnet-4-6 -p`) |
+| AI Pipeline | Agent CLI provider subprocess (`claude` / `codex`) |
 | Deployment | Local / single-machine |
 
 ---

--- a/docs/guides/backend-guide.md
+++ b/docs/guides/backend-guide.md
@@ -213,10 +213,10 @@ class CocomoSettings(BaseModel):
     working_days_per_month: float
 
 class LLMSettings(BaseModel):
-    # LLM ops run via CLI subprocess (claude / codex) — no API keys stored here.
+    # LLM ops run via agent CLI subprocess providers (claude / codex) — no API keys stored here.
     # Authenticate once with: `claude auth login` or `codex auth`
-    cli_tool: Literal["claude", "codex"]
-    model: str  # Passed as --model flag when supported by the CLI
+    provider: Literal["claude", "codex"]
+    model: str  # Passed through the selected provider adapter
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
@@ -246,8 +246,8 @@ cocomo:
   working_days_per_month: 21.67
 
 llm:
-  cli_tool: "claude"          # "claude" | "codex"
-  model: "claude-sonnet-4-6"  # Passed via --model flag
+  provider: "claude"          # "claude" | "codex"
+  model: "claude-sonnet-4-6"  # Passed through the provider adapter
 
 optimizer:
   population: 100
@@ -305,7 +305,7 @@ be/
 │   │   │   └── repositories/      # Concrete repo implementations
 │   │   │       └── <domain>.py
 │   │   ├── llm/
-│   │   │   └── client.py          # CLI subprocess wrapper (claude / codex)
+│   │   │   └── client.py          # CLI subprocess provider wrapper (claude / codex)
 │   │   └── db/migrations/         # Alembic env + versions
 │   │
 │   └── interfaces/                # HTTP interface — no business logic

--- a/docs/guides/backend-guide.md
+++ b/docs/guides/backend-guide.md
@@ -304,7 +304,7 @@ be/
 │   │   │   │   └── <domain>.py
 │   │   │   └── repositories/      # Concrete repo implementations
 │   │   │       └── <domain>.py
-│   │   ├── llm/
+│   │   ├── agent_cli/
 │   │   │   └── client.py          # CLI subprocess provider wrapper (claude / codex)
 │   │   └── db/migrations/         # Alembic env + versions
 │   │


### PR DESCRIPTION
## Summary

This PR makes the backend LLM execution path provider-based so Codex can be supported as a first-class agent CLI alongside the existing Claude CLI behavior.

The previous implementation exposed `llm.cli_tool: "claude" | "codex"`, but the actual subprocess calls assumed a Claude-shaped command contract: `<cli> --model <model> -p <prompt>`. That made `codex` a config option in name only, because Codex uses `codex exec --model <model> -` for non-interactive prompt execution.

## Root Cause

The backend treated an agent CLI as just an executable name. In practice each CLI has its own contract for prompt execution, model selection, stdin support, MCP listing, timeout behavior, and error reporting. Those provider-specific details were leaking into the shared MCP collector and LLM runner.

## Changes

- Added `be/app/infrastructure/agent_cli/` with a shared `AgentCliProvider` protocol, provider factory, subprocess helper, and Claude/Codex adapters.
- Updated the analysis pipeline to pass an agent provider through P1/P2/P3/scoring/P4-P8 instead of passing `cli_tool` strings.
- Updated `LLMMCPCollector` to use provider methods for MCP source discovery and prompt execution.
- Added Codex support using `codex exec --model <model> -` with prompt input passed via stdin.
- Changed config from `llm.cli_tool` to `llm.provider`, while keeping `cli_tool` accepted as a deprecated compatibility alias.
- Reused the stronger JSON parsing path for MCP LLM responses so fenced JSON/preamble output is handled better.
- Added tests for Claude/Codex provider command construction and updated MCP collector tests to use fake providers.
- Added `docs/design/agent-cli-provider-design.md` with implementation notes and future CLI extensibility guidance.
- Updated backend docs to describe provider-based CLI execution.

## Validation

- `../venv/bin/python -m compileall app tests/infrastructure/test_agent_cli.py tests/infrastructure/test_collectors.py`
- Smoke checked provider command construction:
  - Claude: `['claude', '--model', 'claude-sonnet-4-6', '-p', 'hello']`
  - Codex: `['codex', 'exec', '--model', 'gpt-5.4', '-']` with prompt passed through stdin

Pytest was not run because neither `uv` nor `pytest` is installed in the available local environments.

## Notes

Future CLI agents should now be added by creating a new provider adapter and registering it in the factory. Shared analysis pipeline code should not need provider-specific branches as long as the CLI supports non-interactive prompt input and text/JSON output.
